### PR TITLE
Bump version to 0.2

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -20,5 +20,5 @@ branches:
     - feature
     - support
     - hotfix
-next-version: "0.1"
+next-version: "0.2"
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,0 +1,5 @@
+# Ais.Net.Receiver release notes
+
+## v0.2.0
+
+* Add Errors observable to `Ais.Net.Receiver.Receiver.ReceiverHost` https://github.com/ais-dotnet/Ais.Net.Receiver/pull/142


### PR DESCRIPTION
We've added new API surface area—the new `Errors` observable added by #141 — so we need to increment the minor version accordingly.