### PR TITLE
Adding UnixTimestamp + Parse message type 27

### DIFF
--- a/Solutions/Ais.Net.Models.Specs/Features/AisMessageType18.feature.cs
+++ b/Solutions/Ais.Net.Models.Specs/Features/AisMessageType18.feature.cs
@@ -26,7 +26,7 @@ namespace Corvus.Configuration.Specs.Features
         
         private TechTalk.SpecFlow.ITestRunner testRunner;
         
-        private string[] _featureTags = ((string[])(null));
+        private static string[] featureTags = ((string[])(null));
         
 #line 1 "AisMessageType18.feature"
 #line hidden
@@ -35,7 +35,7 @@ namespace Corvus.Configuration.Specs.Features
         public virtual void FeatureSetup()
         {
             testRunner = TechTalk.SpecFlow.TestRunnerManager.GetTestRunner();
-            TechTalk.SpecFlow.FeatureInfo featureInfo = new TechTalk.SpecFlow.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "Features", "AisMessageType18", null, ProgrammingLanguage.CSharp, ((string[])(null)));
+            TechTalk.SpecFlow.FeatureInfo featureInfo = new TechTalk.SpecFlow.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "Features", "AisMessageType18", null, ProgrammingLanguage.CSharp, featureTags);
             testRunner.OnFeatureStart(featureInfo);
         }
         
@@ -47,28 +47,28 @@ namespace Corvus.Configuration.Specs.Features
         }
         
         [NUnit.Framework.SetUpAttribute()]
-        public virtual void TestInitialize()
+        public void TestInitialize()
         {
         }
         
         [NUnit.Framework.TearDownAttribute()]
-        public virtual void TestTearDown()
+        public void TestTearDown()
         {
             testRunner.OnScenarioEnd();
         }
         
-        public virtual void ScenarioInitialize(TechTalk.SpecFlow.ScenarioInfo scenarioInfo)
+        public void ScenarioInitialize(TechTalk.SpecFlow.ScenarioInfo scenarioInfo)
         {
             testRunner.OnScenarioInitialize(scenarioInfo);
             testRunner.ScenarioContext.ScenarioContainer.RegisterInstanceAs<NUnit.Framework.TestContext>(NUnit.Framework.TestContext.CurrentContext);
         }
         
-        public virtual void ScenarioStart()
+        public void ScenarioStart()
         {
             testRunner.OnScenarioStart();
         }
         
-        public virtual void ScenarioCleanup()
+        public void ScenarioCleanup()
         {
             testRunner.CollectScenarioErrors();
         }

--- a/Solutions/Ais.Net.Models.Specs/Features/AisMessageType18.feature.cs
+++ b/Solutions/Ais.Net.Models.Specs/Features/AisMessageType18.feature.cs
@@ -26,7 +26,7 @@ namespace Corvus.Configuration.Specs.Features
         
         private TechTalk.SpecFlow.ITestRunner testRunner;
         
-        private static string[] featureTags = ((string[])(null));
+        private string[] _featureTags = ((string[])(null));
         
 #line 1 "AisMessageType18.feature"
 #line hidden
@@ -35,7 +35,7 @@ namespace Corvus.Configuration.Specs.Features
         public virtual void FeatureSetup()
         {
             testRunner = TechTalk.SpecFlow.TestRunnerManager.GetTestRunner();
-            TechTalk.SpecFlow.FeatureInfo featureInfo = new TechTalk.SpecFlow.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "Features", "AisMessageType18", null, ProgrammingLanguage.CSharp, featureTags);
+            TechTalk.SpecFlow.FeatureInfo featureInfo = new TechTalk.SpecFlow.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "Features", "AisMessageType18", null, ProgrammingLanguage.CSharp, ((string[])(null)));
             testRunner.OnFeatureStart(featureInfo);
         }
         
@@ -47,28 +47,28 @@ namespace Corvus.Configuration.Specs.Features
         }
         
         [NUnit.Framework.SetUpAttribute()]
-        public void TestInitialize()
+        public virtual void TestInitialize()
         {
         }
         
         [NUnit.Framework.TearDownAttribute()]
-        public void TestTearDown()
+        public virtual void TestTearDown()
         {
             testRunner.OnScenarioEnd();
         }
         
-        public void ScenarioInitialize(TechTalk.SpecFlow.ScenarioInfo scenarioInfo)
+        public virtual void ScenarioInitialize(TechTalk.SpecFlow.ScenarioInfo scenarioInfo)
         {
             testRunner.OnScenarioInitialize(scenarioInfo);
             testRunner.ScenarioContext.ScenarioContainer.RegisterInstanceAs<NUnit.Framework.TestContext>(NUnit.Framework.TestContext.CurrentContext);
         }
         
-        public void ScenarioStart()
+        public virtual void ScenarioStart()
         {
             testRunner.OnScenarioStart();
         }
         
-        public void ScenarioCleanup()
+        public virtual void ScenarioCleanup()
         {
             testRunner.CollectScenarioErrors();
         }

--- a/Solutions/Ais.Net.Models/Ais/Net/Models/Abstractions/IAisMessage.cs
+++ b/Solutions/Ais.Net.Models/Ais/Net/Models/Abstractions/IAisMessage.cs
@@ -4,7 +4,7 @@
 
 namespace Ais.Net.Models.Abstractions
 {
-    public interface IAisMessage : IVesselIdentity, IAisMessageType
+    public interface IAisMessage : IVesselIdentity, IAisMessageType, ITimestamp
     {
     }
 }

--- a/Solutions/Ais.Net.Models/Ais/Net/Models/Abstractions/IAisMessageType27.cs
+++ b/Solutions/Ais.Net.Models/Ais/Net/Models/Abstractions/IAisMessageType27.cs
@@ -1,0 +1,17 @@
+﻿namespace Ais.Net.Models.Abstractions
+{
+    public interface IAisMessageType27
+    {
+        float? CourseOverGroundDegrees { get; }
+        
+        bool NotGnssPosition { get; }
+        
+        NavigationStatus NavigationStatus { get; }
+        
+        Position? Position { get; }
+        
+        bool PositionAccuracy { get; }
+        
+        float? SpeedOverGround { get; }
+    }
+}

--- a/Solutions/Ais.Net.Models/Ais/Net/Models/Abstractions/ITimestamp.cs
+++ b/Solutions/Ais.Net.Models/Ais/Net/Models/Abstractions/ITimestamp.cs
@@ -1,0 +1,6 @@
+﻿namespace Ais.Net.Models.Abstractions;
+
+public interface ITimestamp
+{
+    public long? UnixTimestamp { get; }
+}

--- a/Solutions/Ais.Net.Models/Ais/Net/Models/Abstractions/Position.cs
+++ b/Solutions/Ais.Net.Models/Ais/Net/Models/Abstractions/Position.cs
@@ -8,5 +8,7 @@ namespace Ais.Net.Models.Abstractions
     {
         public static Position From10000thMins(int latitude, int longitude) =>
             new (latitude.From10000thMinsToDegrees(), longitude.From10000thMinsToDegrees());
+        public static Position From10thMins(int latitude, int longitude) =>
+            new (latitude.From10thMinsToDegrees(), longitude.From10thMinsToDegrees());
     }
 }

--- a/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageBase.cs
+++ b/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageBase.cs
@@ -6,5 +6,5 @@ namespace Ais.Net.Models
 {
     using Ais.Net.Models.Abstractions;
 
-    public record AisMessageBase(int MessageType, uint Mmsi) : IAisMessage;
+    public record AisMessageBase(int MessageType, uint Mmsi, long? UnixTimestamp) : IAisMessage;
 }

--- a/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageExtensions.cs
+++ b/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageExtensions.cs
@@ -14,6 +14,11 @@ namespace Ais.Net.Models
         {
             return value / 600000.0;
         }
+        
+        public static double From10thMinsToDegrees(this int value)
+        {
+            return value / 600.0;
+        }
 
         public static float? FromTenths(this uint value)
         {

--- a/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageType18.cs
+++ b/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageType18.cs
@@ -24,8 +24,9 @@ namespace Ais.Net.Models
         uint RepeatIndicator,
         float? SpeedOverGround,
         uint TimeStampSecond,
-        uint TrueHeadingDegrees) :
-            AisMessageBase(MessageType: 18, Mmsi),
+        uint TrueHeadingDegrees,
+        long? UnixTimestamp) :
+            AisMessageBase(MessageType: 18, Mmsi, UnixTimestamp),
             IAisMessageType18,
             IAisIsAssigned,
             IRaimFlag,

--- a/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageType19.cs
+++ b/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageType19.cs
@@ -27,8 +27,9 @@ namespace Ais.Net.Models
         uint Spare308,
         float? SpeedOverGround,
         uint TimeStampSecond,
-        uint TrueHeadingDegrees) :
-            AisMessageBase(MessageType: 19, Mmsi),
+        uint TrueHeadingDegrees,
+        long? UnixTimestamp) :
+            AisMessageBase(MessageType: 19, Mmsi, UnixTimestamp),
             IAisMessageType19,
             IAisIsAssigned,
             IAisIsDteNotReady,

--- a/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageType1Through3.cs
+++ b/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageType1Through3.cs
@@ -23,8 +23,9 @@ namespace Ais.Net.Models
         uint SpareBits145,
         float? SpeedOverGround,
         uint TimeStampSecond,
-        uint TrueHeadingDegrees) :
-            AisMessageBase(MessageType, Mmsi),
+        uint TrueHeadingDegrees,
+        long? UnixTimestamp) :
+            AisMessageBase(MessageType, Mmsi, UnixTimestamp),
             IAisMessageType1to3,
             IRaimFlag,
             IRepeatIndicator,

--- a/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageType24Part0.cs
+++ b/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageType24Part0.cs
@@ -10,8 +10,9 @@ namespace Ais.Net.Models
         uint Mmsi,
         uint PartNumber,
         uint RepeatIndicator,
-        uint Spare160) :
-            AisMessageBase(MessageType: 24, Mmsi),
+        uint Spare160,
+        long? UnixTimestamp) :
+            AisMessageBase(MessageType: 24, Mmsi, UnixTimestamp),
             IAisMultipartMessage,
             IRepeatIndicator,
             IAisMessageType24Part0;

--- a/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageType24Part1.cs
+++ b/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageType24Part1.cs
@@ -21,8 +21,9 @@ namespace Ais.Net.Models
         ShipType ShipType,
         uint UnitModelCode,
         string VendorIdRev3,
-        string VendorIdRev4) :
-            AisMessageBase(MessageType: 24, Mmsi),
+        string VendorIdRev4,
+        long? UnixTimestamp) :
+            AisMessageBase(MessageType: 24, Mmsi, UnixTimestamp),
             IAisMessageType24Part1,
             IAisMultipartMessage,
             ICallSign,

--- a/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageType27.cs
+++ b/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageType27.cs
@@ -1,0 +1,24 @@
+﻿// <copyright file="AisMessageType18.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Ais.Net.Models
+{
+    using Ais.Net.Models.Abstractions;
+
+    public record AisMessageType27(
+        float? CourseOverGroundDegrees,
+        bool NotGnssPosition,
+        uint Mmsi,
+        NavigationStatus NavigationStatus,
+        Position? Position,
+        bool PositionAccuracy,
+        bool RaimFlag,
+        uint RepeatIndicator,
+        float? SpeedOverGround,
+        long? UnixTimestamp) :
+            AisMessageBase(MessageType: 27, Mmsi, UnixTimestamp),
+            IAisMessageType27,
+            IRaimFlag,
+            IRepeatIndicator;
+}

--- a/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageType5.cs
+++ b/Solutions/Ais.Net.Models/Ais/Net/Models/AisMessageType5.cs
@@ -26,8 +26,9 @@ namespace Ais.Net.Models
         uint RepeatIndicator,
         ShipType ShipType,
         uint Spare423,
-        string VesselName) :
-            AisMessageBase(MessageType: 5, Mmsi),
+        string VesselName,
+        long? UnixTimestamp) :
+            AisMessageBase(MessageType: 5, Mmsi, UnixTimestamp),
             IAisMessageType5,
             IAisIsDteNotReady,
             IAisPositionFixType,

--- a/Solutions/Ais.Net.Receiver/Ais/Net/Receiver/Parser/NmeaToAisMessageTypeProcessor.cs
+++ b/Solutions/Ais.Net.Receiver/Ais/Net/Receiver/Parser/NmeaToAisMessageTypeProcessor.cs
@@ -30,31 +30,31 @@ namespace Ais.Net.Receiver.Parser
                 {
                     case >= 1 and <= 3:
                         {
-                            this.ParseMessageTypes1Through3(asciiPayload, padding, messageType);
+                            this.ParseMessageTypes1Through3(parsedLine, asciiPayload, padding, messageType);
                             return;
                         }
 
                     case 5:
                         {
-                            this.ParseMessageType5(asciiPayload, padding);
+                            this.ParseMessageType5(parsedLine, asciiPayload, padding);
                             return;
                         }
 
                     case 18:
                         {
-                            this.ParseMessageType18(asciiPayload, padding);
+                            this.ParseMessageType18(parsedLine, asciiPayload, padding);
                             return;
                         }
 
                     case 19:
                         {
-                            this.ParseMessageType19(asciiPayload, padding);
+                            this.ParseMessageType19(parsedLine, asciiPayload, padding);
                             return;
                         }
 
                     case 24:
                         {
-                            this.ParseMessageType24(asciiPayload, padding);
+                            this.ParseMessageType24(parsedLine, asciiPayload, padding);
                             return;
                         }
                 }
@@ -87,7 +87,7 @@ namespace Ais.Net.Receiver.Parser
             throw new NotImplementedException();
         }
 
-        private void ParseMessageTypes1Through3(ReadOnlySpan<byte> asciiPayload, uint padding, int messageType)
+        private void ParseMessageTypes1Through3(NmeaLineParser nmeaLineParser, ReadOnlySpan<byte> asciiPayload, uint padding, int messageType)
         {
             var parser = new NmeaAisPositionReportClassAParser(asciiPayload, padding);
 
@@ -108,12 +108,13 @@ namespace Ais.Net.Receiver.Parser
                 SpareBits145: parser.SpareBits145,
                 SpeedOverGround: parser.SpeedOverGroundTenths.FromTenths(),
                 TimeStampSecond: parser.TimeStampSecond,
-                TrueHeadingDegrees: parser.TrueHeadingDegrees);
+                TrueHeadingDegrees: parser.TrueHeadingDegrees,
+                UnixTimestamp: nmeaLineParser.TagBlock.UnixTimestamp);
 
             this.messages.OnNext(message);
         }
 
-        private void ParseMessageType5(ReadOnlySpan<byte> asciiPayload, uint padding)
+        private void ParseMessageType5(NmeaLineParser nmeaLineParser, ReadOnlySpan<byte> asciiPayload, uint padding)
         {
             var parser = new NmeaAisStaticAndVoyageRelatedDataParser(asciiPayload, padding);
 
@@ -137,12 +138,13 @@ namespace Ais.Net.Receiver.Parser
                 DimensionToStern: parser.DimensionToStern,
                 Draught10thMetres: parser.Draught10thMetres,
                 Spare423: parser.Spare423,
-                PositionFixType: parser.PositionFixType);
+                PositionFixType: parser.PositionFixType,
+                UnixTimestamp: nmeaLineParser.TagBlock.UnixTimestamp);
 
             this.messages.OnNext(message);
         }
 
-        private void ParseMessageType18(ReadOnlySpan<byte> asciiPayload, uint padding)
+        private void ParseMessageType18(NmeaLineParser nmeaLineParser, ReadOnlySpan<byte> asciiPayload, uint padding)
         {
             var parser = new NmeaAisPositionReportClassBParser(asciiPayload, padding);
 
@@ -164,12 +166,13 @@ namespace Ais.Net.Receiver.Parser
                 TrueHeadingDegrees: parser.TrueHeadingDegrees,
                 IsAssigned: parser.IsAssigned,
                 RaimFlag: parser.RaimFlag,
-                RepeatIndicator: parser.RepeatIndicator);
+                RepeatIndicator: parser.RepeatIndicator,
+                UnixTimestamp: nmeaLineParser.TagBlock.UnixTimestamp);
 
             this.messages.OnNext(message);
         }
 
-        private void ParseMessageType19(ReadOnlySpan<byte> asciiPayload, uint padding)
+        private void ParseMessageType19(NmeaLineParser nmeaLineParser, ReadOnlySpan<byte> asciiPayload, uint padding)
         {
             var parser = new NmeaAisPositionReportExtendedClassBParser(asciiPayload, padding);
 
@@ -197,12 +200,13 @@ namespace Ais.Net.Receiver.Parser
                 SpeedOverGround: parser.SpeedOverGroundTenths.FromTenths(),
                 TimeStampSecond: parser.TimeStampSecond,
                 TrueHeadingDegrees: parser.TrueHeadingDegrees,
-                Position: Position.From10000thMins(parser.Latitude10000thMins, parser.Longitude10000thMins));
+                Position: Position.From10000thMins(parser.Latitude10000thMins, parser.Longitude10000thMins),
+                UnixTimestamp: nmeaLineParser.TagBlock.UnixTimestamp);
 
             this.messages.OnNext(message);
         }
 
-        private void ParseMessageType24(ReadOnlySpan<byte> asciiPayload, uint padding)
+        private void ParseMessageType24(NmeaLineParser nmeaLineParser, ReadOnlySpan<byte> asciiPayload, uint padding)
         {
             uint part = NmeaAisStaticDataReportParser.GetPartNumber(asciiPayload, padding);
 
@@ -219,7 +223,8 @@ namespace Ais.Net.Receiver.Parser
                             Mmsi: parser.Mmsi,
                             PartNumber: parser.PartNumber,
                             RepeatIndicator: parser.RepeatIndicator,
-                            Spare160: parser.Spare160);
+                            Spare160: parser.Spare160,
+                            UnixTimestamp: nmeaLineParser.TagBlock.UnixTimestamp);
 
                         this.messages.OnNext(message);
                         break;
@@ -253,7 +258,8 @@ namespace Ais.Net.Receiver.Parser
                             Spare162: parser.Spare162,
                             UnitModelCode: parser.UnitModelCode,
                             VendorIdRev3: vendorIdRev3Ascii.GetString(),
-                            VendorIdRev4: vendorIdRev4Ascii.GetString());
+                            VendorIdRev4: vendorIdRev4Ascii.GetString(),
+                            UnixTimestamp: nmeaLineParser.TagBlock.UnixTimestamp);
 
                         this.messages.OnNext(message);
                         break;

--- a/Solutions/Ais.Net.Receiver/Ais/Net/Receiver/Parser/NmeaToAisMessageTypeProcessor.cs
+++ b/Solutions/Ais.Net.Receiver/Ais/Net/Receiver/Parser/NmeaToAisMessageTypeProcessor.cs
@@ -57,6 +57,12 @@ namespace Ais.Net.Receiver.Parser
                             this.ParseMessageType24(parsedLine, asciiPayload, padding);
                             return;
                         }
+
+                    case 27:
+                        {
+                            this.ParseMessageType27(parsedLine, asciiPayload, padding);
+                            return;
+                        }
                 }
             }
             catch (Exception e)
@@ -265,6 +271,25 @@ namespace Ais.Net.Receiver.Parser
                         break;
                     }
             }
+        }
+
+        private void ParseMessageType27(NmeaLineParser nmeaLineParser, ReadOnlySpan<byte> asciiPayload, uint padding)
+        {
+            var parser = new NmeaAisLongRangeAisBroadcastParser(asciiPayload, padding);
+
+            var message = new AisMessageType27(
+                Mmsi: parser.Mmsi,
+                Position: Position.From10thMins(parser.Latitude10thMins, parser.Longitude10thMins),
+                CourseOverGroundDegrees: parser.CourseOverGroundDegrees,
+                PositionAccuracy: parser.PositionAccuracy,
+                SpeedOverGround: parser.SpeedOverGroundTenths.FromTenths(),
+                RaimFlag: parser.RaimFlag,
+                RepeatIndicator: parser.RepeatIndicator,
+                NotGnssPosition: parser.NotGnssPosition,
+                NavigationStatus: parser.NavigationStatus,
+                UnixTimestamp: nmeaLineParser.TagBlock.UnixTimestamp);
+
+            this.messages.OnNext(message);
         }
     }
 }


### PR DESCRIPTION
I have come accross the need to have the UnixTimestamp from the Nmea message so I implemented the following in order to accomplish that.

Library already read and extracted the timestamp I just needed to add it to the message records so it could be used outside the library.

This pull request also contains the parsing of message type 27 which you already had a decoder for in Ais.Net